### PR TITLE
Update the docs for `readarr` to note it is deprecated.

### DIFF
--- a/docs/apps/readarr.md
+++ b/docs/apps/readarr.md
@@ -1,4 +1,11 @@
+---
+status: deprecated
+---
 # Readarr
+
+## DEPRECATED
+
+DEPRECATION NOTICE: This image is deprecated as of 2026-07-29.
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/readarr?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/readarr)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-readarr?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-readarr)


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Add front matter and visible deprecation notice to the Readarr app documentation, including the deprecation date.