### PR TITLE
chore: update doc build trigger

### DIFF
--- a/.github/workflows/trigger-site-build.yml
+++ b/.github/workflows/trigger-site-build.yml
@@ -16,5 +16,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT_TRIGGER_BUILD }}
-          repository: GhostWriters/DockSTARTer
+          repository: GhostWriters/DockSTARTer-Docs
           event-type: templates-update


### PR DESCRIPTION
Updates the repository dispatch target to GhostWriters/DockSTARTer-Docs.

## Summary by Sourcery

CI:
- Retarget the repository-dispatch workflow to trigger builds on GhostWriters/DockSTARTer-Docs.