### PR TITLE
Pin the deprecated `doplarr` image to the last known working tag, `3…8.0`

### DIFF
--- a/.apps/doplarr/.env
+++ b/.apps/doplarr/.env
@@ -7,4 +7,4 @@ DOPLARR<__INSTANCE>__STORAGE_ON=''     # Blank uses DOCKER_STORAGE_ON value. Set
 DOPLARR<__INSTANCE>__STORAGE2_ON=''    # Blank uses DOCKER_STORAGE2_ON value. Set to YES/NO to override
 DOPLARR<__INSTANCE>__STORAGE3_ON=''    # Blank uses DOCKER_STORAGE3_ON value. Set to YES/NO to override
 DOPLARR<__INSTANCE>__STORAGE4_ON=''    # Blank uses DOCKER_STORAGE4_ON value. Set to YES/NO to override
-DOPLARR<__INSTANCE>__TAG='latest'
+DOPLARR<__INSTANCE>__TAG='3.8.0'


### PR DESCRIPTION

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Enhancements:
- Update doplarr environment configuration to use the last known working image tag instead of a floating or newer tag.