### PR TITLE
Fix typo in comment in `.env.app.doplarrrs`

### DIFF
--- a/.apps/doplarrrs/.env.app.doplarrrs
+++ b/.apps/doplarrrs/.env.app.doplarrrs
@@ -1,6 +1,6 @@
 
 ## The following settings will be ignored if you mount a config file.
-## However, the variable defined here can be referenced in the config file by using ${VARNAME} in it.
+## However, the variables defined here can be referenced in the config file by using ${VARNAME} in it.
 ##
 ## You mount a config file by placing the following in your docker-compose.overrride.yml file:
 ##


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Bug Fixes:
- Fix a typographical error in the .env.app.doplarrrs configuration file comment.