### PR TITLE
Use the instance name in `.env.app.doplarrrs` comment

### DIFF
--- a/.apps/doplarrrs/.env.app.doplarrrs
+++ b/.apps/doplarrrs/.env.app.doplarrrs
@@ -6,7 +6,7 @@
 ##
 ##   doplarrrs:
 ##     volumes:
-##       ${DOCKER_VOLUME_CONFIG?}/doplarrrs/config.toml:/config.toml:ro
+##       ${DOCKER_VOLUME_CONFIG?}/doplarrrs<__instance>/config.toml:/config.toml:ro
 ##
 ## An example config file can be found at:
 ##   https://github.com/activexray/doplarr_rs/blob/main/config.example.toml


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Chores:
- Adjust the doplarrrs .env app template comment to use the instance-specific name.