### PR TITLE
Comment out `SELKIES_MANUAL_WIDTH` and `SELKIES_MANUAL_HEIGHT` in `.env.app.calibre`

### DIFF
--- a/.apps/calibre/.env.app.calibre
+++ b/.apps/calibre/.env.app.calibre
@@ -60,8 +60,8 @@ SELKIES_AUDIO_BITRATE='320000'                  # The default audio bitrate.
 
 # Display & Resolution Settings
 SELKIES_IS_MANUAL_RESOLUTION_MODE=False         # Lock the resolution to the manual width/height values.
-SELKIES_MANUAL_WIDTH=0                          # Lock width to a fixed value. Setting this forces manual resolution mode.
-SELKIES_MANUAL_HEIGHT=0                         # Lock height to a fixed value. Setting this forces manual resolution mode.
+#SELKIES_MANUAL_WIDTH=0                         # Lock width to a fixed value. Setting this forces manual resolution mode.
+#SELKIES_MANUAL_HEIGHT=0                        # Lock height to a fixed value. Setting this forces manual resolution mode.
 SELKIES_SCALING_DPI='96'                        # The default DPI for UI scaling.
 
 # Input & Client Behavior Settings


### PR DESCRIPTION
Setting `SELKIES_MANUAL_WIDTH` or `SELKIES_MANUAL_HEIGHT` to ANY value, even 0, forces manual resolution mode.  Comment the values out for documentation instead of setting a default value.

Fixes #149

# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Comment out SELKIES_MANUAL_WIDTH and SELKIES_MANUAL_HEIGHT in the Calibre app env file to avoid forcing manual resolution mode while retaining documentation of the options.

Enhancements:
- Adjust Calibre env configuration to rely on default resolution behavior unless manual dimensions are explicitly set by the user.

Chores:
- Update application configuration to align with documented behavior and resolve issue #149.