### PR TITLE
Fix the "Deprecated" icon not showing on Huntarr

### DIFF
--- a/docs/apps/huntarr.md
+++ b/docs/apps/huntarr.md
@@ -1,5 +1,5 @@
 ---
-deprecated: true
+status: deprecated
 ---
 # Huntarr
 
@@ -10,6 +10,7 @@ DEPRECATION NOTICE: This image has been deprecated as of 2026-02-24.
 We do not recommend using Huntarr, as **serious** security issues [have been brought to light](<https://www.reddit.com/r/selfhosted/comments/1rckopd/huntarr_your_passwords_and_your_entire_arr_stacks>). The developer has also removed the source code repository and all support communities.
 
 If you are exposing Huntarr to the Internet, you should stop immediately and rotate all API keys for any apps connected to Huntarr.
+
 We have completely disabled this app in our templates due to the security concerns.
 
 [![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer-Templates/tree/main/.apps/huntarr)


### PR DESCRIPTION
# Pull request

**Purpose**
Describe the problem or feature in addition to a link to the issues.

**Approach**
How does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
Describe the research stage
Links to blog posts, patterns, libraries or addons used to solve this problem

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Documentation:
- Adjust Huntarr documentation front matter to use the standard status: deprecated field so the deprecation indicator renders properly.