### PR TITLE
Add missing docs pages for `Cloudflared`, `Obsidian`, `Paperless-ngx`, and `UniFi Network Application`

### DIFF
--- a/docs/apps/cloudflared.md
+++ b/docs/apps/cloudflared.md
@@ -1,0 +1,19 @@
+# Cloudflared
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/cloudflare/cloudflared?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/cloudflare/cloudflared)
+[![GitHub Stars](https://img.shields.io/github/stars/cloudflare/cloudflared?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/cloudflare/cloudflared)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer-Templates/tree/main/.apps/cloudflared)
+
+## Description
+
+[Cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+is the Cloudflare Tunnel client. It creates an outbound-only connection to
+Cloudflare's network so you can expose private services to the internet
+without opening ports on your firewall.
+
+## Install/Setup
+
+Set `TUNNEL_TOKEN` in the app environment to the tunnel token from the
+Cloudflare Zero Trust dashboard (Networks → Tunnels). The token authenticates
+this connector to your Cloudflare account, and the routes to your services
+are configured in that dashboard rather than in DockSTARTer.

--- a/docs/apps/obsidian.md
+++ b/docs/apps/obsidian.md
@@ -1,0 +1,18 @@
+# Obsidian
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/obsidian?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/obsidian)
+[![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-obsidian?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-obsidian)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer-Templates/tree/main/.apps/obsidian)
+
+## Description
+
+[Obsidian](https://obsidian.md/) is a note-taking app that works on top of a
+local folder of plain text Markdown files, with linking between notes, a
+graph view, and a large plugin ecosystem. This container runs the desktop
+app in your browser.
+
+## Install/Setup
+
+This application does not have any specific setup instructions documented. If
+you need assistance setting up this application please visit our
+[support page](https://dockstarter.com/basics/support/).

--- a/docs/apps/paperlessngx.md
+++ b/docs/apps/paperlessngx.md
@@ -1,0 +1,17 @@
+# Paperless-ngx
+
+[![GitHub Container Registry](https://img.shields.io/badge/ghcr.io-paperless--ngx-607D8B?style=flat-square&logo=github)](https://github.com/paperless-ngx/paperless-ngx/pkgs/container/paperless-ngx)
+[![GitHub Stars](https://img.shields.io/github/stars/paperless-ngx/paperless-ngx?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/paperless-ngx/paperless-ngx)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer-Templates/tree/main/.apps/paperlessngx)
+
+## Description
+
+[Paperless-ngx](https://docs.paperless-ngx.com/) is a community-supported
+open-source document management system that transforms your physical
+documents into a searchable online archive so you can keep less paper.
+
+## Install/Setup
+
+This app includes the required PostgreSQL and Redis services. Make sure to
+set a strong password for `PAPERLESS_DBPASS` in the app environment before
+starting it.

--- a/docs/apps/unifinetworkapplication.md
+++ b/docs/apps/unifinetworkapplication.md
@@ -1,0 +1,17 @@
+# UniFi Network Application
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/unifi-network-application?style=flat-square&color=607D8B&label=docker%20pulls&logo=docker)](https://hub.docker.com/r/linuxserver/unifi-network-application)
+[![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-unifi-network-application?style=flat-square&color=607D8B&label=github%20stars&logo=github)](https://github.com/linuxserver/docker-unifi-network-application)
+[![Compose Templates](https://img.shields.io/static/v1?style=flat-square&color=607D8B&label=compose&message=templates)](https://github.com/GhostWriters/DockSTARTer-Templates/tree/main/.apps/unifinetworkapplication)
+
+## Description
+
+The [UniFi Network Application](https://ui.com/) is Ubiquiti's software for
+managing UniFi network devices such as access points, switches, and gateways
+from a web UI.
+
+## Install/Setup
+
+This app includes the required MongoDB service. Make sure to set a strong
+password for `MONGO_PASS` in the app environment before starting it. The web
+UI is served over HTTPS on port 8443.


### PR DESCRIPTION
**Purpose**
The Validate workflow fails on main because these four non-deprecated apps have no docs page. Follow-up from the discussion on #158.

**Approach**
Adds a docs page for each app following the existing format. Cloudflared, Paperless-ngx, and UniFi Network Application get short setup notes for the settings that must be filled in before first start (`TUNNEL_TOKEN`, `PAPERLESS_DBPASS`, `MONGO_PASS`); Obsidian uses the standard support-page boilerplate.

**Requirements**

- [x] These changes meet the standards for [contributing](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/GhostWriters/DockSTARTer/blob/main/.github/CODE_OF_CONDUCT.md).

## Summary by Sourcery

Add documentation pages for four existing applications to resolve missing docs in the workflow.

Documentation:
- Add a docs page for Cloudflared with a description and setup notes for the required TUNNEL_TOKEN environment value.
- Add a docs page for Obsidian with basic description and support-link boilerplate for setup assistance.
- Add a docs page for Paperless-ngx describing the app and highlighting the need to set PAPERLESS_DBPASS before first start.
- Add a docs page for UniFi Network Application describing the app and noting MongoDB inclusion and required MONGO_PASS configuration.